### PR TITLE
more pythonic argument parsing in respotify client

### DIFF
--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import argparse
+import getpass
 import sys; sys.path.append("../..")
 from spotify_web.friendly import Spotify, SpotifyTrack, SpotifyUserlist
 from threading import Thread, Lock, Event
@@ -235,14 +237,22 @@ def heartbeat_handler():
 
 if __name__ == '__main__':
 
-    if len(sys.argv) < 2:
-        print "Usage: "+sys.argv[0]+" <username> <password>"
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description='Command line Spotify client')
+    parser.add_argument('username', help='Your spotify username')
+    parser.add_argument('password', nargs='?', default=None,
+                        help='<Optional> your spotify password')
 
-    spotify = Spotify(sys.argv[1], sys.argv[2])
+    args = parser.parse_args()
+
+    if args.password is None:
+        args.password = getpass.getpass("Please enter your Spotify password")
+
+    import pdb; pdb.set_trace()
+    spotify = Spotify(args.username, args.password)
     if spotify:
         os.system("kill `pgrep -f respotify-helper` &> /dev/null")
-        uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py", sys.argv[1], sys.argv[2]])
+        uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py", 
+                                        args.username, args.password])
         with client:
             client.connect(host="localhost", port="6600")
         Thread(target=heartbeat_handler).start()

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -232,25 +232,28 @@ def heartbeat_handler():
 			client.status()
 		heartbeat_marker.get(timeout=15)
 
-if len(sys.argv) < 2:
-	print "Usage: "+sys.argv[0]+" <username> <password>"
-	sys.exit(1)
 
-spotify = Spotify(sys.argv[1], sys.argv[2])
-if spotify:
-	os.system("kill `pgrep -f respotify-helper` &> /dev/null")
-	uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py", sys.argv[1], sys.argv[2]])
-	with client:
-		client.connect(host="localhost", port="6600")
-	Thread(target=heartbeat_handler).start()
-	command_loop()
-	os.system("clear")
-	with client:
-		client.clear()
-		client.disconnect()
-		client = None
-		heartbeat_marker.set()
-	uri_resolver.kill()
-else:
-	print "Login failed"
-	sys.exit(1)
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        print "Usage: "+sys.argv[0]+" <username> <password>"
+        sys.exit(1)
+
+    spotify = Spotify(sys.argv[1], sys.argv[2])
+    if spotify:
+        os.system("kill `pgrep -f respotify-helper` &> /dev/null")
+        uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py", sys.argv[1], sys.argv[2]])
+        with client:
+            client.connect(host="localhost", port="6600")
+        Thread(target=heartbeat_handler).start()
+        command_loop()
+        os.system("clear")
+        with client:
+            client.clear()
+            client.disconnect()
+            client = None
+            heartbeat_marker.set()
+        uri_resolver.kill()
+    else:
+        print "Login failed"
+        sys.exit(1)

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -247,9 +247,8 @@ if __name__ == '__main__':
     if args.password is None:
         args.password = getpass.getpass("Please enter your Spotify password")
 
-    import pdb; pdb.set_trace()
     spotify = Spotify(args.username, args.password)
-    if spotify:
+    if spotify.logged_in():
         os.system("kill `pgrep -f respotify-helper` &> /dev/null")
         uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py", 
                                         args.username, args.password])


### PR DESCRIPTION
Hi there Hexxeh,

I cleaned up the respotify client to use **name** == "**main**" as the entrance point and in addition I've also used argparse to grab the arguments off the command line which is the more standard way to do it.

As I'm using argparse I also chucked getpass in there so you don't have to stick the password into your command line history unless you explicitly want to.

I've got some more changes but will package them up appropriately.

Cheers
Andrew
