### PR TITLE
Follow up to my previous push. Changed demo client to read correct wss setting. Added error code

### DIFF
--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -201,7 +201,7 @@ def command_info(*args):
     print "Username: " + spotify.api.username
     print "Account type: " + spotify.api.account_type
     print "Country: " + spotify.api.country
-    print "Connected to " + spotify.api.settings["aps"]["ws"][0].replace("wss://", "").replace(":443", "")
+    print "Connected to " + spotify.api.settings["wss"].replace("wss://", "").replace(":443", "").replace("/", "")
 
 
 def command_help(*args):
@@ -259,7 +259,7 @@ def heartbeat_handler():
     while client is not None:
         with client:
             client.status()
-        heartbeat_marker.get(timeout=15)
+        heartbeat_marker.wait(timeout=15)
 
 
 if __name__ == '__main__':

--- a/spotify_web/spotify.py
+++ b/spotify_web/spotify.py
@@ -721,6 +721,7 @@ class SpotifyAPI():
         minor = err["error"][1]
 
         major_err = {
+            8: "Rate request error",
             12: "Track error",
             13: "Hermes error",
             14: "Hermes service error",


### PR DESCRIPTION
1) Forgot that the demo client read the wss setting for the 'info' command. Fixed that in respotify.py
2) respotify.py was also trying to use Event.get() rather than Event.wait()
3) Added error code 8 'Rate request error' - pretty sure this is correct, however it appears when trying to log in so I may be wrong. I got this from the js file on play.spotify.com. I'm happy to remove if needed.
