### PR TITLE
Add a search path when invoking the respotify helper program.

### DIFF
--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -117,7 +117,7 @@ def command_uri(*args):
 
 
 def command_album(*args):
-    if args[0][0] == "" or current_playlist is None:
+    if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
     index = int(args[0][0])-1

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -120,6 +120,9 @@ def command_album(*args):
     if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
+    if type(args[0][0]) != int:
+        return
+
     index = int(args[0][0])-1
     if current_playlist.getNumTracks() < index:
         return

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -88,8 +88,10 @@ def command_list(*args):
         print "Playlists\n"
         index = 1
         for playlist in rootlist:
-            print " ["+str(index)+"] "+playlist.getName()
-            index += 1
+            name = playlist.getName()
+            if name != None:
+                print " ["+str(index)+"] "+name
+                index += 1
     else:
         try:
             if len(rootlist) >= int(args[0][0]):

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -135,6 +135,9 @@ def command_artist(*args):
     if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
+    if type(args[0][0]) != int:
+        return
+
     index = int(args[0][0])-1
     if current_playlist.getNumTracks() < index:
         return

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -129,7 +129,7 @@ def command_album(*args):
 
 
 def command_artist(*args):
-    if args[0][0] == "" or current_playlist is None:
+    if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
     index = int(args[0][0])-1

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -288,7 +288,7 @@ if __name__ == '__main__':
     if spotify.logged_in():
         os.system("kill `pgrep -f respotify-helper` &> /dev/null")
         uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py",
-                                        args.username, args.password], env={"PATH": "%%PREFIX%%/bin"})
+                                        args.username, args.password])
         with client:
             client.connect(host="localhost", port="6600")
         Thread(target=heartbeat_handler).start()

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
     if spotify.logged_in():
         os.system("kill `pgrep -f respotify-helper` &> /dev/null")
         uri_resolver = subprocess.Popen([sys.executable, "respotify-helper.py",
-                                        args.username, args.password])
+                                        args.username, args.password], env={"PATH": "%%PREFIX%%/bin"})
         with client:
             client.connect(host="localhost", port="6600")
         Thread(target=heartbeat_handler).start()

--- a/clients/respotify/respotify.py
+++ b/clients/respotify/respotify.py
@@ -120,10 +120,11 @@ def command_album(*args):
     if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
-    if type(args[0][0]) != int:
+    try:
+        index = int(args[0][0])-1
+    except:
         return
 
-    index = int(args[0][0])-1
     if current_playlist.getNumTracks() < index:
         return
 
@@ -135,10 +136,11 @@ def command_artist(*args):
     if len(*args) == 0 or args[0][0] == "" or current_playlist is None:
         return
 
-    if type(args[0][0]) != int:
+    try:
+        index = int(args[0][0])-1
+    except:
         return
 
-    index = int(args[0][0])-1
     if current_playlist.getNumTracks() < index:
         return
 

--- a/spotify_web/friendly.py
+++ b/spotify_web/friendly.py
@@ -244,6 +244,8 @@ class SpotifyPlaylist(SpotifyObject):
         uri_parts = self.uri.split(":")
         if len(uri_parts) == 4:
             return uri_parts[3]
+        elif len(uri_parts) == 3:
+            return None
         else:
             return uri_parts[4]
 
@@ -251,7 +253,7 @@ class SpotifyPlaylist(SpotifyObject):
         return self.uri
 
     def getName(self):
-        return "Starred" if self.getID() == "starred" else self.obj.attributes.name
+        return "Starred" if self.getID() == "starred" else (None if self.obj == False else self.obj.attributes.name)
 
     def rename(self, name):
         ret = self.spotify.api.rename_playlist(self.getURI(), name)


### PR DESCRIPTION
This allows running respotify from a different directory than the current
one, which is the expected behaviour when running it as part of a package.

The search path must be set by modifying the %%PREFIX%% variable, e.g.
to "/usr" for Ubuntu packages or "/usr/local" for FreeBSD packages.
