### PR TITLE
Bugfix when calculating uri from id

### DIFF
--- a/spotify_web/spotify.py
+++ b/spotify_web/spotify.py
@@ -103,7 +103,7 @@ class SpotifyUtil():
             res = [v % 62] + res
             v /= 62
         id = ''.join([base62[i] for i in res])
-        return ("spotify:"+uritype+":"+id).rjust(22, "0")
+        return ("spotify:"+uritype+":"+id.rjust(22, "0"))
 
     @staticmethod
     def uri2id(uri):


### PR DESCRIPTION
There was an tiny error in the id2uri function. This leads to invalid uris when the real one started with zeros.
